### PR TITLE
Fix auth service import

### DIFF
--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -1,4 +1,3 @@
-import apiClient from '@/services/apiClient'
 // src/services/auth.js
 import jwtDecode from 'jwt-decode'
 


### PR DESCRIPTION
## Summary
- remove obsolete apiClient import from auth service

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ba0c3660c832783309ef640213952