### PR TITLE
Fix navigation to use orgCode parameter

### DIFF
--- a/frontend/src/components/header.vue
+++ b/frontend/src/components/header.vue
@@ -6,7 +6,7 @@
         <ul class="flex gap-2 h-full">
           <li v-for="item in menuItems" :key="item.label" class="h-full">
             <router-link
-              :to="item.route"
+              :to="{ name: item.name, params: { orgCode } }"
               class="desktop-link h-full flex items-center"
               :class="isActive(item) ? 'desktop-active' : 'desktop-inactive'"
             >
@@ -32,18 +32,19 @@ import { ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 const route = useRoute()
+const orgCode = route.params.orgCode
 const router = useRouter()
 const dropdownOpen = ref(false)
 const username = ref('Max Mustermann')
 
 const menuItems = [
-  { label: 'Material', route: '/material' },
-  { label: 'Bestellung', route: '/bestellung' },
-  { label: 'Buchhaltung', route: '/buchhaltung' },
-  { label: 'Einstellungen', route: '/admin' }
+  { label: 'Material', name: 'material' },
+  { label: 'Bestellung', name: 'bestellung' },
+  { label: 'Buchhaltung', name: 'buchhaltung' },
+  { label: 'Einstellungen', name: 'admin' }
 ]
 
-const isActive = (item) => route.path.startsWith(item.route)
+const isActive = (item) => route.name === item.name
 
 function toggleDropdown() {
   dropdownOpen.value = !dropdownOpen.value

--- a/frontend/src/components/mobile-nav.vue
+++ b/frontend/src/components/mobile-nav.vue
@@ -3,10 +3,10 @@
     <router-link
   v-for="item in navItems"
   :key="item.label"
-  :to="item.route"
+  :to="{ name: item.name, params: { orgCode } }"
   class="nav-button"
-  :class="isActive(item.route) ? 'nav-active' : 'nav-inactive'"
-  @click="console.log('Klicke auf:', item.route)"
+  :class="isActive(item) ? 'nav-active' : 'nav-inactive'"
+  @click="console.log('Klicke auf:', item.name)"
 >
       <component :is="item.icon" class="nav-icon" />
       <span class="nav-label">{{ item.label }}</span>
@@ -31,14 +31,15 @@ import {
 } from 'lucide-vue-next'
 
 const route = useRoute()
+const orgCode = route.params.orgCode
 const emit = defineEmits(['open-more'])
 
 const navItems = [
-  { icon: HomeIcon, label: 'Material', route: '/material' },
-  { icon: SearchIcon, label: 'Bestellung', route: '/bestellung' },
-  { icon: PlusCircleIcon, label: 'Neu', route: '/neu' },
-  { icon: BellIcon, label: 'Reparatur', route: '/reparatur' },
+  { icon: HomeIcon, label: 'Material', name: 'material' },
+  { icon: SearchIcon, label: 'Bestellung', name: 'bestellung' },
+  { icon: PlusCircleIcon, label: 'Neu', name: 'neu' },
+  { icon: BellIcon, label: 'Reparatur', name: 'reparatur' },
 ]
 
-const isActive = (r) => route.path.startsWith(r)
+const isActive = (item) => route.name === item.name
 </script>

--- a/frontend/src/components/mobile-sidebar.vue
+++ b/frontend/src/components/mobile-sidebar.vue
@@ -3,8 +3,8 @@
     <aside v-if="modelValue" class="mobile-sidebar">
       <h2 class="font-bold text-lg mb-4">Mehr</h2>
       <ul class="space-y-2">
-        <li><router-link to="/buchhaltung" @click="close">Buchhaltung</router-link></li>
-        <li><router-link to="/admin" @click="close">Admin</router-link></li>
+        <li><router-link :to="{ name: 'buchhaltung', params: { orgCode } }" @click="close">Buchhaltung</router-link></li>
+        <li><router-link :to="{ name: 'admin', params: { orgCode } }" @click="close">Admin</router-link></li>
         <li>
           <button class="close-button" @click="close">Menü schließen</button>
         </li>
@@ -22,10 +22,15 @@
 </template>
 
 <script setup>
+import { useRoute } from 'vue-router'
+
 defineProps({
   modelValue: Boolean
 })
 const emit = defineEmits(['update:modelValue'])
+
+const route = useRoute()
+const orgCode = route.params.orgCode
 
 function close() {
   emit('update:modelValue', false)


### PR DESCRIPTION
## Summary
- load `orgCode` from the current route
- switch desktop and mobile navigation links to named routes with orgCode params
- adjust active state checks for route names

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685bbdcd0d3883279f282a4738da7939