### PR TITLE
Add login error message handling

### DIFF
--- a/frontend/src/pages/login.vue
+++ b/frontend/src/pages/login.vue
@@ -18,6 +18,7 @@
         Login
       </button>
     </form>
+    <p v-if="errorMessage" class="text-red-500 mt-2">{{ errorMessage }}</p>
   </div>
 </template>
 
@@ -28,6 +29,7 @@ import { login } from '@/services/auth'
 
 const email = ref('')
 const password = ref('')
+const errorMessage = ref('')
 const router = useRouter()
 
 const doLogin = async () => {
@@ -40,8 +42,10 @@ const doLogin = async () => {
     }
 
     router.push(`/${orgCode}/material`)
+    errorMessage.value = ''
   } catch (err) {
     console.error('Login fehlgeschlagen:', err)
+    errorMessage.value = err.message || 'Login fehlgeschlagen'
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- display error message in login form when authentication fails
- clear the message on successful login

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c10a9eb808327adbf55898982b8c9